### PR TITLE
Add tensor based cfpq and rsm utils

### DIFF
--- a/project/automaton_builders.py
+++ b/project/automaton_builders.py
@@ -8,6 +8,7 @@ from pyformlang.finite_automaton import (
 )
 
 import networkx as nx
+from pyformlang.rsa import RecursiveAutomaton
 
 
 def regex_to_dfa(regex: str) -> DeterministicFiniteAutomaton:
@@ -34,3 +35,29 @@ def graph_to_nfa(
         enfa.add_final_state(State(state))
 
     return enfa.remove_epsilon_transitions()
+
+
+def rsm_to_nfa(rsm: RecursiveAutomaton) -> NondeterministicFiniteAutomaton:
+    result_nfa = NondeterministicFiniteAutomaton()
+    for automaton_name in rsm.labels:
+        automaton = rsm.boxes[automaton_name].dfa
+        transition_map = automaton.to_dict()
+
+        initial_nfa_state = (automaton.start_state, automaton_name)
+        result_nfa.add_start_state(initial_nfa_state)
+
+        for accepting_state in automaton.final_states:
+            final_nfa_state = (accepting_state, automaton_name)
+            result_nfa.add_final_state(final_nfa_state)
+
+        for origin_state in transition_map:
+            for transition_symbol, destination_state in transition_map[
+                origin_state
+            ].items():
+                nfa_origin = (origin_state, automaton_name)
+                nfa_destination = (destination_state, automaton_name)
+                result_nfa.add_transition(
+                    nfa_origin, transition_symbol, nfa_destination
+                )
+
+    return result_nfa

--- a/project/context_free_path_query.py
+++ b/project/context_free_path_query.py
@@ -1,6 +1,7 @@
 from pyformlang.cfg import CFG, Terminal
 import networkx as nx
 from project.cfg_utils import cfg_to_weak_normal_form
+from scipy import sparse
 
 
 def hellings_based_cfpq(
@@ -62,3 +63,72 @@ def hellings_based_cfpq(
         if is_correct_path:
             result.add((start, end))
     return result
+
+
+def matrix_based_cfpq(
+    grammar: CFG,
+    input_graph: nx.DiGraph,
+    starting_vertices: set[int] = None,
+    ending_vertices: set[int] = None,
+) -> set[tuple[int, int]]:
+    vertex_index_map = {}
+    index_vertex_map = {}
+
+    for idx, vertex in enumerate(input_graph.nodes):
+        vertex_index_map[vertex] = idx
+        index_vertex_map[idx] = vertex
+
+    normalized_grammar = cfg_to_weak_normal_form(grammar)
+    grammar_rules = normalized_grammar.productions
+    nullable_symbols = normalized_grammar.get_nullable_symbols()
+
+    graph_size = input_graph.number_of_nodes()
+
+    terminal_matrices = {
+        var: sparse.csr_matrix((graph_size, graph_size), dtype=bool)
+        for var in normalized_grammar.variables
+    }
+
+    graph_edges = input_graph.edges(data="label")
+
+    for source, target, edge_label in graph_edges:
+        for rule in grammar_rules:
+            if rule.body == [Terminal(edge_label)]:
+                src_idx = vertex_index_map[source]
+                tgt_idx = vertex_index_map[target]
+                terminal_matrices[rule.head][src_idx, tgt_idx] = True
+
+    for null_sym in nullable_symbols:
+        for diagonal_idx in range(graph_size):
+            terminal_matrices[null_sym][diagonal_idx, diagonal_idx] = True
+
+    processing_queue = set(normalized_grammar.variables)
+
+    while processing_queue:
+        current_var = processing_queue.pop()
+
+        for rule in grammar_rules:
+            if current_var in rule.body:
+                product_matrix = (
+                    terminal_matrices[rule.body[0]] @ terminal_matrices[rule.body[1]]
+                )
+
+                if (product_matrix > terminal_matrices[rule.head]).count_nonzero() > 0:
+                    terminal_matrices[rule.head] += product_matrix
+                    processing_queue.add(rule.head)
+
+    path_pairs = set()
+
+    for row_idx in range(graph_size):
+        for col_idx in range(graph_size):
+            start_vertex = index_vertex_map[row_idx]
+            end_vertex = index_vertex_map[col_idx]
+
+            if (
+                terminal_matrices[normalized_grammar.start_symbol][row_idx, col_idx]
+                and (not starting_vertices or start_vertex in starting_vertices)
+                and (not ending_vertices or end_vertex in ending_vertices)
+            ):
+                path_pairs.add((start_vertex, end_vertex))
+
+    return path_pairs

--- a/project/context_free_path_query.py
+++ b/project/context_free_path_query.py
@@ -1,4 +1,3 @@
-import pyformlang
 from pyformlang.cfg import CFG, Terminal
 import networkx as nx
 from pyformlang.rsa import RecursiveAutomaton

--- a/project/context_free_path_query.py
+++ b/project/context_free_path_query.py
@@ -1,5 +1,10 @@
+import pyformlang
 from pyformlang.cfg import CFG, Terminal
 import networkx as nx
+from pyformlang.rsa import RecursiveAutomaton
+
+from project.adjacency_matrix_fa import AdjacencyMatrixFA, intersect_automata
+from project.automaton_builders import graph_to_nfa, rsm_to_nfa
 from project.cfg_utils import cfg_to_weak_normal_form
 from scipy import sparse
 
@@ -132,3 +137,69 @@ def matrix_based_cfpq(
                 path_pairs.add((start_vertex, end_vertex))
 
     return path_pairs
+
+
+def tensor_based_cfpq(
+    rsm: RecursiveAutomaton,
+    graph: nx.DiGraph,
+    start_nodes: set[int] = None,
+    final_nodes: set[int] = None,
+) -> set[tuple[int, int]]:
+    rsm_fa = AdjacencyMatrixFA(rsm_to_nfa(rsm))
+    graph_fa = AdjacencyMatrixFA(graph_to_nfa(graph, start_nodes, final_nodes))
+
+    g_size = graph_fa.state_cnt
+    changed = True
+
+    while changed:
+        changed = False
+        combined = intersect_automata(rsm_fa, graph_fa)
+        closure = combined.get_transitive_closure()
+        rows, cols = closure.nonzero()
+
+        for pos_r, pos_c in zip(rows, cols):
+            left_rsm = pos_r // g_size
+            left_graph = pos_r % g_size
+
+            right_rsm = pos_c // g_size
+            right_graph = pos_c % g_size
+
+            _, s_lbl = rsm_fa.state_of_id[left_rsm].value
+            _, t_lbl = rsm_fa.state_of_id[right_rsm].value
+
+            if s_lbl != t_lbl:
+                continue
+
+            if (
+                left_rsm not in rsm_fa.start_vector.nonzero()[0]
+                or right_rsm not in rsm_fa.final_vector.nonzero()[0]
+            ):
+                continue
+
+            mats = graph_fa.boolean_decomp_by_symbol
+            if s_lbl not in mats:
+                mats[s_lbl] = sparse.csr_matrix((g_size, g_size), dtype=bool)
+
+            if not mats[s_lbl][left_graph, right_graph]:
+                mats[s_lbl][left_graph, right_graph] = True
+                changed = True
+
+    results = set()
+
+    if rsm.initial_label not in graph_fa.boolean_decomp_by_symbol:
+        return results
+
+    mtx = graph_fa.boolean_decomp_by_symbol[rsm.initial_label]
+
+    for i in range(g_size):
+        for j in range(g_size):
+            if not mtx[i, j]:
+                continue
+
+            start_ok = (not start_nodes) or (graph_fa.state_of_id[i] in start_nodes)
+            final_ok = (not final_nodes) or (graph_fa.state_of_id[j] in final_nodes)
+
+            if start_ok and final_ok:
+                results.add((graph_fa.state_of_id[i], graph_fa.state_of_id[j]))
+
+    return results

--- a/project/rsm_utils.py
+++ b/project/rsm_utils.py
@@ -1,0 +1,10 @@
+import pyformlang
+from pyformlang.rsa import RecursiveAutomaton
+
+
+def cfg_to_rsm(cfg: pyformlang.cfg.CFG) -> RecursiveAutomaton:
+    return ebnf_to_rsm(cfg.to_text())
+
+
+def ebnf_to_rsm(ebnf: str) -> RecursiveAutomaton:
+    return RecursiveAutomaton.from_text(ebnf)

--- a/tests/autotests/test_task07.py
+++ b/tests/autotests/test_task07.py
@@ -11,8 +11,7 @@ from cfpq_concrete_cases import CASES_CFPQ, CaseCFPQ
 
 # Fix import statements in try block to run tests
 try:
-    from project.task6 import hellings_based_cfpq
-    from project.task7 import matrix_based_cfpq
+    from project.context_free_path_query import hellings_based_cfpq, matrix_based_cfpq
 except ImportError:
     pytestmark = pytest.mark.skip("Task 7 is not ready to test!")
 

--- a/tests/autotests/test_task08.py
+++ b/tests/autotests/test_task08.py
@@ -15,9 +15,12 @@ from cfpq_concrete_cases import CASES_CFPQ, CaseCFPQ
 
 # Fix import statements in try block to run tests
 try:
-    from project.task6 import hellings_based_cfpq
-    from project.task7 import matrix_based_cfpq
-    from project.task8 import tensor_based_cfpq, cfg_to_rsm, ebnf_to_rsm
+    from project.context_free_path_query import (
+        hellings_based_cfpq,
+        matrix_based_cfpq,
+        tensor_based_cfpq,
+    )
+    from project.rsm_utils import cfg_to_rsm, ebnf_to_rsm
 except ImportError:
     pytestmark = pytest.mark.skip("Task 8 is not ready to test!")
 


### PR DESCRIPTION
A tensor-based reachability algorithm is implemented, determining which pairs of graph nodes are connected by paths described by a context-free grammar.
Additionally, the conversion of CFG and EBNF into a recursive state machine (RSM) is implemented, using SciPy matrices to perform all necessary boolean tensor and closure operations.